### PR TITLE
Support PEP3149 ABI tags.

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env -S python3 -W default
 import warnings; warnings.simplefilter('default')
 
-import distutils.sysconfig
+try:
+  import sysconfig
+except ImportError:
+  from distutils import sysconfig
 import os 
 import sys
 
@@ -30,7 +33,7 @@ if "Py_DEBUG" not in os.environ:
 else:
   Py_DEBUG = [('Py_DEBUG',1)]
 
-libpython_so = distutils.sysconfig.get_config_var('INSTSONAME')
+libpython_so = sysconfig.get_config_var('INSTSONAME')
 ext_modules = [
     Extension(
       "pam_python",

--- a/src/setup.py
+++ b/src/setup.py
@@ -41,7 +41,7 @@ ext_modules = [
       include_dirs = [],
       library_dirs=[],
       define_macros=[('LIBPYTHON_SO','"'+libpython_so+'"')] + Py_DEBUG,
-      libraries=["pam","python%d.%d" % sys.version_info[:2]],
+      libraries=["pam","python%d.%d%s" % ( sys.version_info[0], sys.version_info[1], sysconfig.get_config_var('ABIFLAGS'))],
     ), ]
 
 setup(


### PR DESCRIPTION
PEP3149 introduced ABI tags which allow to have multiple libpython variants installed at the same time (even for one specific version - like debug variants, variants compiled with a different memory allocator etc.)

When explicitly linking libpython via distutils, which is strictly required since Python 3.8, make sure to include these ABI tags.

Debian and Ubuntu probably don't need them, but other operating systems make use of ABI tags.

This PR also switches from the deprecated distutils.sysconfig module to just sysconfig. This change should be transparent.